### PR TITLE
syntax error corrected

### DIFF
--- a/plug_pass_prototype_0_1.ino
+++ b/plug_pass_prototype_0_1.ino
@@ -6,7 +6,7 @@
 #include <Adafruit_PN532.h>
 #include "RfidDb.h"
 
-RfidDb database = RfidDB(4,8,4);
+RfidDb db = RfidDb(4,8,4);
 
 uint32_t id1 = 0xFFFFFF01;
 


### PR DESCRIPTION
found a syntax error in RfidDb reference.  The changed code compiles and reads a card.